### PR TITLE
Add README note re: thread count global variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Ruby threads means the requests will be issued very quickly, well
 before the responses start coming back. As responses come back, they
 will be processed as they arrive.
 
+Thread Count
+----------------
+
+The thread count defaults to 64 and is set based on `$pmap_default_thread_count`.
+
 Example
 -------
 


### PR DESCRIPTION
I'd like to suggest adding this note to the README.

I've found myself digging into the source code a couple times to re-assign the thread count.  Seems like a good idea to have it in README since this has been a repeated question for me :+1:.

Btw, this is a very handy gem for creating a quick & dirty threaded solution (I've been using it with web requests).
