### PR TITLE
Refactor with peach_with_index and a ThreadPool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 pmap [![Build Status](https://secure.travis-ci.org/bruceadams/pmap.png)](http://travis-ci.org/bruceadams/pmap) [![Code Climate](https://codeclimate.com/github/bruceadams/pmap.png)](https://codeclimate.com/github/bruceadams/pmap)
 ====
 
-This Ruby gem adds two methods to any Enumerable (notably including
+This Ruby gem adds three methods to any Enumerable (notably including
 any Array). The two added methods are:
 
 * _pmap_ parallel map
 * _peach_ parallel each
+* _peach_with_index_ parallel each_with_index
 
 Threading in Ruby has limitations.
 ----------------------------------

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -5,49 +5,18 @@ require_relative "pmap/thread_pool"
 $pmap_default_thread_count ||= 64
 
 module PMap
-  class DummyOutput
-    def []=(idx, val)
-    end
-  end
-
   def self.included(base)
     base.class_eval do
       # Parallel "map" for any Enumerable.
       # Requires a block of code to run for each Enumerable item.
       # [thread_count] is number of threads to create. Optional.
       def pmap(thread_count=nil, &proc)
-        in_array = self.to_a        # I'm not sure how expensive this is...
-        out_array = Array.new(in_array.size)
-        process_core(thread_count, in_array, out_array, &proc)
-        out_array
+        Array.new.tap do |result|
+          peach_with_index(thread_count) do |item, index|
+            result[index] = proc.call(item)
+          end
+        end
       end
-
-      def process_core(thread_count, in_array, out_array, &proc)
-        thread_count = thread_count(thread_count, in_array)
-        size = in_array.size
-
-        semaphore = Mutex.new
-        index = -1                  # Our use of index is protected by semaphore
-
-        threads = (0...thread_count).map {
-          Thread.new {
-            i = nil
-            while (semaphore.synchronize {i = (index += 1)}; i < size)
-              out_array[i] = yield(in_array[i])
-            end
-          }
-        }
-        threads.each {|t| t.join}
-      end
-      private :process_core
-
-      def thread_count(user_requested_count, items)
-        user_requested_count ||= $pmap_default_thread_count
-        raise ArgumentError, "thread_count must be at least one." unless
-          user_requested_count.respond_to?(:>=) && user_requested_count >= 1
-        [user_requested_count, items.size].min
-      end
-      private :thread_count
 
       # Parallel "each" for any Enumerable.
       # Requires a block of code to run for each Enumerable item.

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -1,5 +1,5 @@
 require 'thread' unless defined?(Mutex)
-require_relative "pmap/thread_pool"
+require "pmap/thread_pool"
 
 # Global variable for the default thread pool size.
 $pmap_default_thread_count ||= 64

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -53,7 +53,9 @@ module PMap
       # Requires a block of code to run for each Enumerable item.
       # [thread_count] is number of threads to create. Optional.
       def peach(thread_count=nil, &proc)
-        process_core(thread_count, self.to_a, DummyOutput.new, &proc)
+        peach_with_index(thread_count) do |item, index|
+          proc.call(item)
+        end
         self
       end
 

--- a/lib/pmap/thread_pool.rb
+++ b/lib/pmap/thread_pool.rb
@@ -1,0 +1,70 @@
+# Internal: A thread pool for managing the threads used by the pmap functions
+#
+# Example:
+#
+#   pool = PMap::ThreadPool.new(16)
+#   array.each do |item|
+#     pool.schedule do 
+#       item.some_io_intense_operation
+#     end
+#   end
+#
+#   pool.shutdown
+#
+module PMap
+  class ThreadPool
+
+    # Public: Initializes a new thread pool
+    #
+    # max - the maximum number of threads to spawn
+    #
+    def initialize(max)
+      raise ArgumentError, "max must be at least one." unless
+        max.respond_to?(:>=) && max >= 1
+
+      @max = max
+      @shutting_down = false
+      @jobs = Queue.new
+      @workers = []
+    end
+
+    # Public: Schedules a new job to run in a thread
+    #
+    # *args - any arguments that will be passed to the block
+    # &job  - the block that will be executed on the thread
+    #
+    def schedule(*args, &job)
+      @jobs << [job, args] 
+      spawn_worker if !@shutting_down && @workers.size < @max 
+    end
+
+    # Public: Shuts down the thread pool and waits for any running threads to
+    #         complete
+    #
+    def shutdown
+      @shutting_down = true
+      @workers.size.times do 
+        schedule { throw(:stop_working) }
+      end
+      @workers.each(&:join)
+    end
+
+    private
+
+    # Private: Spawns a new thread to work on the scheduled jobs
+    #
+    def spawn_worker
+      thread = Thread.new do 
+        catch(:stop_working) do
+          loop do
+            job, args = @jobs.pop
+            job.call(*args)
+          end
+        end
+      end
+
+      @workers << thread 
+    end
+  end
+end
+

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -60,4 +60,15 @@ class Pmap_Test < Test::Unit::TestCase
     assert(elapsed >= 2, 'Limited threads too fast: %.1f seconds' % elapsed)
     assert(elapsed <  3, 'Parallel sleeps too slow: %.1f seconds' % elapsed)
   end
+
+  def test_peach_with_index
+    subject = ["a", "b", "c"]
+    output  = []
+
+    subject.peach_with_index do |letter, index|
+      output << [letter, index]
+    end
+
+    assert_equal([["a", 0], ["b", 1], ["c", 2]].sort, output.sort)
+  end
 end


### PR DESCRIPTION
I really liked this gem, but the conversion to an Array (issue #6) bit me. I implemented an API client that made paginated API requests and exposed those through an `#each` method that Enumerable could be included and used. It would make a request for the first page, yield the results, request the next page, yield the results, etc. With the conversion to an Array, `#pmap` would make all of the requests before enumerating through the results which was undesirable.

So my goals were the following:

* don't convert to an array
* don't call count on the enumerable (for the same reason as converting to an array)
* avoid adding any extra methods to Enumerable that are unnecessary

As you'll see in the commits for this PR I was able to accomplish these goals by:

* only using the existing `#each_with_index` method from Enumerable
* adding a `#peach_with_index` method that is used as the basis for implementing `#pmap` and `#peach`
* moving thread management to a `ThreadPool` class

I think this implementation also addresses several other issues you were concerned with, notably: #9, #4, #3, and #2 