### PR TITLE
Jruby 1.9 fix

### DIFF
--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -15,9 +15,11 @@ module PMap
       # Requires a block of code to run for each Enumerable item.
       #
       def pmap(thread_count=nil, &proc)
+        array_mutex = Mutex.new
         Array.new.tap do |result|
           peach_with_index(thread_count) do |item, index|
-            result[index] = proc.call(item)
+            value = proc.call(item)
+            array_mutex.synchronize { result[index] = value }
           end
         end
       end

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -25,9 +25,11 @@ class Pmap_Test < Test::Unit::TestCase
   end
 
   def test_basic_array
-    proc = Proc.new {|x| x*x*x}
-    array = (1..10).to_a
-    assert_equal(array.map(&proc), array.pmap(&proc))
+    1_000.times do
+      proc = Proc.new {|x| x*x*x}
+      array = (1..10).to_a
+      assert_equal(array.map(&proc), array.pmap(&proc))
+    end
   end
 
   def test_time_savings


### PR DESCRIPTION
When submitting a PR for #16, the `test_basic_array` test failed JRuby-19mode. The `#pmap` array contained `nil` values. Upon further discovery, I found that this happens very infrequently. 

Wrapping the assignment of the mapped value to the result array in a mutex appears to solve the problem. To be sure, I increased the number of times `test_basic_array` is tested from 1 to 1,000.