### PR TITLE
Passes tests that don't pass a block to #pmap

### DIFF
--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -67,7 +67,7 @@ module PMap
       # Requires a block of code to run for each Enumerable item
       #
       def flat_pmap(thread_count=nil, &proc)
-        return flat_map unless proc
+        return flatten(1) unless proc
         
         pmap(thread_count, &proc).flatten(1)
       end

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -67,7 +67,7 @@ module PMap
       # Requires a block of code to run for each Enumerable item
       #
       def flat_pmap(thread_count=nil, &proc)
-        return flatten(1) unless proc
+        return self unless proc
         
         pmap(thread_count, &proc).flatten(1)
       end

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -67,6 +67,8 @@ module PMap
       # Requires a block of code to run for each Enumerable item
       #
       def flat_pmap(thread_count=nil, &proc)
+        return flat_map unless proc
+        
         pmap(thread_count, &proc).flatten(1)
       end
     end

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -15,6 +15,8 @@ module PMap
       # Requires a block of code to run for each Enumerable item.
       #
       def pmap(thread_count=nil, &proc)
+        return self unless proc
+        
         array_mutex = Mutex.new
         Array.new.tap do |result|
           peach_with_index(thread_count) do |item, index|

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -10,9 +10,10 @@ module PMap
 
       # Public: Parallel "map" for any Enumerable.
       #
-      # thread_count - maximum number of threads to create (optional)
+      # When a block is given, each item is yielded to the block in a separate
+      # thread. When no block is given, an Enumerable is returned.
       #
-      # Requires a block of code to run for each Enumerable item.
+      # thread_count - maximum number of threads to create (optional)
       #
       def pmap(thread_count=nil, &proc)
         return self unless proc
@@ -28,9 +29,10 @@ module PMap
 
       # Public: Parallel "each" for any Enumerable.
       #
-      # thread_count - maximum number of threads to create (optional)
+      # When a block is given, each item is yielded to the block in a separate
+      # thread. When no block is given, an Enumerable is returned.
       #
-      # Requires a block of code to run for each Enumerable item.
+      # thread_count - maximum number of threads to create (optional)
       #
       def peach(thread_count=nil, &proc)
         if proc
@@ -41,11 +43,12 @@ module PMap
         self
       end
 
-      # Public: Parallel each_with_index for any Enumerable
+      # Public: Parallel "each_with_index" for any Enumerable
+      #
+      # When a block is given, each item is yielded to the block in a separate
+      # thread. When no block is given, an Enumerable is returned.
       #
       # thread_count - maximum number of threads to create (optional)
-      #
-      # Requires a block of code to run for each Enumerable item.
       #
       def peach_with_index(thread_count=nil, &proc)
         return each_with_index unless proc
@@ -60,11 +63,12 @@ module PMap
         self
       end
 
-      # Public: Parallel flat_map for any Enumerable
+      # Public: Parallel "flat_map" for any Enumerable
+      #
+      # When a block is given, each item is yielded to the block in a separate
+      # thread. When no block is given, an Enumerable is returned.
       #
       # thread_count - maximum number of threads to create (optional)
-      #
-      # Requires a block of code to run for each Enumerable item
       #
       def flat_pmap(thread_count=nil, &proc)
         return self unless proc

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -48,6 +48,8 @@ module PMap
       # Requires a block of code to run for each Enumerable item.
       #
       def peach_with_index(thread_count=nil, &proc)
+        return each_with_index unless proc
+
         thread_count ||= $pmap_default_thread_count
         pool = ThreadPool.new(thread_count)
 

--- a/lib/pmap.rb
+++ b/lib/pmap.rb
@@ -16,7 +16,7 @@ module PMap
       #
       def pmap(thread_count=nil, &proc)
         return self unless proc
-        
+
         array_mutex = Mutex.new
         Array.new.tap do |result|
           peach_with_index(thread_count) do |item, index|
@@ -33,8 +33,10 @@ module PMap
       # Requires a block of code to run for each Enumerable item.
       #
       def peach(thread_count=nil, &proc)
-        peach_with_index(thread_count) do |item, index|
-          proc.call(item)
+        if proc
+          peach_with_index(thread_count) do |item, index|
+            proc.call(item)
+          end
         end
         self
       end

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -8,9 +8,9 @@ require 'pmap'
 
 class Pmap_Test < Test::Unit::TestCase
 
-  def bad_test_noproc_range
+  def test_noproc_range
     range = (1..10)
-    assert_equal(range.map, range.pmap)
+    assert_equal(range.map.to_a, range.pmap.to_a)
   end
 
   def test_basic_range
@@ -19,9 +19,9 @@ class Pmap_Test < Test::Unit::TestCase
     assert_equal(range.map(&proc), range.pmap(&proc))
   end
 
-  def bad_test_noproc_array
+  def test_noproc_array
     array = (1..10).to_a
-    assert_equal(array.map, array.pmap)
+    assert_equal(array.map.to_a, array.pmap.to_a)
   end
 
   def test_basic_array

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -101,6 +101,8 @@ class Pmap_Test < Test::Unit::TestCase
 
     if subject.respond_to?(:flat_map)
       assert_equal(subject.flat_map.to_a, subject.flat_pmap.to_a)
+    else
+      assert_equal(subject.map.flatten(1).to_a, subject.flat_pmap.to_a)
     end
   end
 end

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -102,7 +102,7 @@ class Pmap_Test < Test::Unit::TestCase
     if subject.respond_to?(:flat_map)
       assert_equal(subject.flat_map.to_a, subject.flat_pmap.to_a)
     else
-      assert_equal(subject.map.flatten(1).to_a, subject.flat_pmap.to_a)
+      assert_equal(subject.map.to_a, subject.flat_pmap.to_a)
     end
   end
 end

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -13,6 +13,11 @@ class Pmap_Test < Test::Unit::TestCase
     assert_equal(range.map.to_a, range.pmap.to_a)
   end
 
+  def test_noproc_peach
+    range = (1..10)
+    assert_equal(range.each.to_a, range.peach.to_a)
+  end
+
   def test_basic_range
     proc = Proc.new {|x| x*x}
     range = (1..10)
@@ -31,6 +36,7 @@ class Pmap_Test < Test::Unit::TestCase
       assert_equal(array.map(&proc), array.pmap(&proc))
     end
   end
+
 
   def test_time_savings
     start = Time.now

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -95,4 +95,12 @@ class Pmap_Test < Test::Unit::TestCase
       assert_equal(subject.map(&proc).flatten(1), subject.flat_pmap(&proc))
     end
   end
+
+  def test_noproc_flat_pmap
+    subject = [["a"], [["b"]], [[["c"]]]]
+
+    if subject.respond_to?(:flat_map)
+      assert_equal(subject.flat_map.to_a, subject.flat_pmap.to_a)
+    end
+  end
 end

--- a/test/pmap_test.rb
+++ b/test/pmap_test.rb
@@ -18,6 +18,11 @@ class Pmap_Test < Test::Unit::TestCase
     assert_equal(range.each.to_a, range.peach.to_a)
   end
 
+  def test_noproc_peach_with_index
+    range = (1..10)
+    assert_equal(range.each_with_index.to_a, range.peach_with_index.to_a)
+  end
+
   def test_basic_range
     proc = Proc.new {|x| x*x}
     range = (1..10)


### PR DESCRIPTION
I noticed a few "bad" tests, so I thought I'd take a swing at getting them to pass. The following is from the first commit message that explains the rationale:

> With the normal #map method, the documentation states "If no block is given, an enumerator is returned instead". Based on this premise, self can be returned when a block isn't given because self is an enumerator.
 
> For the test to pass, we must compare the _results_ of enumeration of both `#pmap` and `#map`. Comparing the enumerators themselves may yield different classes. Therefore `#to_a` is compared,  which effectively normalizes the results of enumeration.

In implementing each method, I found that reverting back to the non-parallel default methods with an early return was the best approach. Without a block nothing really needs to be done in parallel, and it's likely faster to just let the native method do the work.
